### PR TITLE
Some improvements

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,4 @@
 *.vs*
 *build*
 .vscode
+.cache

--- a/README.md
+++ b/README.md
@@ -64,7 +64,7 @@ The corresponding output is
 Fish: can swim 1 and can walk 0
 Horse: can swim 0 and can walk 1
 Turtle: can swim 1 and can walk 1
-Debug info on all regestry entries:
+Debug info on all registry entries:
    3 components of type class ECS::ComponentContainer<struct Animal>
    2 components of type class ECS::ComponentContainer<struct WaterAnimal>
    2 components of type class ECS::ComponentContainer<struct LandAnimal>
@@ -128,7 +128,7 @@ int main(int argc, char* argv[])
 	animals_oop.push_back(&fish_oop);
 	animals_oop.push_back(&horse_oop);
 	//animals_oop.push_back(&turtle_oop); 
-	// ERROR: the base class is ambigious, 
+	// ERROR: the base class is ambiguous, 
 	// see https://stackoverflow.com/questions/44878627/inheritance-causes-ambiguous-conversion
 	
 	animals_oop.push_back(static_cast<LandAnimalOOP*>(&turtle_oop)); 

--- a/src/ecs_demo.cpp
+++ b/src/ecs_demo.cpp
@@ -117,7 +117,7 @@ int main(int argc, char* argv[])
 	std::vector<AnimalOOP*> animals_oop;
 	animals_oop.push_back(&fish_oop);
 	animals_oop.push_back(&horse_oop);
-	//animals_oop.push_back(&turtle_oop); // ERROR: the base class is ambigious, see mroe here: https://stackoverflow.com/questions/44878627/inheritance-causes-ambiguous-conversion
+	//animals_oop.push_back(&turtle_oop); // ERROR: the base class is ambiguous, see more here: https://stackoverflow.com/questions/44878627/inheritance-causes-ambiguous-conversion
 	animals_oop.push_back(static_cast<LandAnimalOOP*>(&turtle_oop)); // WARNING: this compiles, but now the turtle is not able to swim!
 	
 	// Print the names and abilities of all animals

--- a/src/tinyECS/tiny_ecs.hpp
+++ b/src/tinyECS/tiny_ecs.hpp
@@ -19,7 +19,7 @@ public:
 struct ContainerInterface
 {
     virtual void clear() = 0;
-    virtual size_t size() = 0;
+    virtual std::size_t size() = 0;
     virtual void remove(Entity e) = 0;
     virtual bool has(Entity entity) = 0;
 };
@@ -109,7 +109,7 @@ public:
     }
 
     // Report the number of components of type 'Component'
-    size_t size()
+    std::size_t size()
     {
         return components.size();
     }

--- a/src/tinyECS/tiny_ecs.hpp
+++ b/src/tinyECS/tiny_ecs.hpp
@@ -21,7 +21,7 @@ struct ContainerInterface
     virtual void clear() = 0;
     virtual std::size_t size() = 0;
     virtual void remove(Entity e) = 0;
-    virtual bool has(Entity entity) = 0;
+    virtual bool has(Entity e) = 0;
 };
 
 // A container that stores components of type 'Component' and associated entities
@@ -74,8 +74,8 @@ public:
     }
 
     // Check if entity has a component of type 'Component'
-    bool has(Entity entity) {
-        return map_entity_componentID.count(entity) > 0;
+    bool has(Entity e) {
+        return map_entity_componentID.count(e) > 0;
     }
 
     // Remove an component and pack the container to re-use the empty space

--- a/src/tinyECS/tiny_ecs.hpp
+++ b/src/tinyECS/tiny_ecs.hpp
@@ -4,16 +4,16 @@
 #include <unordered_map>
 #include <assert.h>
 
-// Unique identifyer for all entities
+// Unique identifier for all entities
 class Entity
 {
     unsigned int id;
-    static unsigned int id_count; // starts from 1, entit 0 is the default initialization
+    static unsigned int id_count; // starts from 1, entity 0 is the default initialization
 public:
     Entity()
     {
         id = id_count++;
-        // Note, indices of already deleted entities arent re-used in this simple implementation.
+        // Note, indices of already deleted entities aren't re-used in this simple implementation.
     }
     operator unsigned int() { return id; } // this enables automatic casting to int
 };

--- a/src/tinyECS/tiny_ecs.hpp
+++ b/src/tinyECS/tiny_ecs.hpp
@@ -10,11 +10,8 @@ class Entity
     unsigned int id;
     static unsigned int id_count; // starts from 1, entity 0 is the default initialization
 public:
-    Entity()
-    {
-        id = id_count++;
-        // Note, indices of already deleted entities aren't re-used in this simple implementation.
-    }
+    // Note, indices of already deleted entities aren't re-used in this simple implementation.
+    Entity() : id(id_count++) {}
     operator unsigned int() { return id; } // this enables automatic casting to int
 };
 

--- a/src/tinyECS/tiny_ecs.hpp
+++ b/src/tinyECS/tiny_ecs.hpp
@@ -81,23 +81,22 @@ public:
     // Remove an component and pack the container to re-use the empty space
     void remove(Entity e)
     {
-        if (has(e))
-        {
-            // Get the current position
-            int cID = map_entity_componentID[e];
+        if (!has(e)) return;
 
-            // Move the last element to position cID using the move operator
-            // Note, components[cID] = components.back() would trigger the copy instead of move operator
-            components[cID] = std::move(components.back());
-            entities[cID] = entities.back(); // the entity is only a single index, copy it.
-            map_entity_componentID[entities.back()] = cID;
+        // Get the current position
+        int cID = map_entity_componentID[e];
 
-            // Erase the old component and free its memory
-            map_entity_componentID.erase(e);
-            components.pop_back();
-            entities.pop_back();
-            // Note, one could mark the id for re-use
-        }
+        // Move the last element to position cID using the move operator
+        // Note, components[cID] = components.back() would trigger the copy instead of move operator
+        components[cID] = std::move(components.back());
+        entities[cID] = entities.back(); // the entity is only a single index, copy it.
+        map_entity_componentID[entities.back()] = cID;
+
+        // Erase the old component and free its memory
+        map_entity_componentID.erase(e);
+        components.pop_back();
+        entities.pop_back();
+        // Note, one could mark the id for re-use
     };
 
     // Remove all components of type 'Component'


### PR DESCRIPTION
This PR does the following:
- Refactor insert and emplace methods so that insert uses emplace instead of the other way around so that the component isn't copied in the emplace method when it's passed to the insert method
- Invert if statement for early return in remove method for better readability
- Use initializer list in Entity constructor
- Use std::size_t instead of size_t for consistency
- Rename parameter 'entity' of 'has' to 'e' for consistency with other functions
- Add .cache to .gitignore
- Fix some typos